### PR TITLE
Reflect Discord SDK distribution update

### DIFF
--- a/usage/menubar.rst
+++ b/usage/menubar.rst
@@ -61,7 +61,7 @@ Tools
 * **Update status bar icons:** enable the activity lights on :doc:`status bar <statusbar>` icons. Unchecking this option may improve emulation performance on low-end host systems.
 * **Enable Discord integration:** enable Discord Rich Presence. 86Box shares the emulated machine's name, model and CPU with other Discord users.
 
-.. note:: Discord integration will not be available if the Discord desktop app is not running, or if the included ``discord_game_sdk.dll`` file is missing from the 86Box directory.
+.. note:: In order to use the Discord integration, you need to download the [Discord Game SDK](https://dl-game-sdk.discordapp.net/2.5.6/discord_game_sdk.zip) and copy the ``discord_game_sdk.dll`` library from the ``lib/x86`` or ``lib/x86_64`` directory (depending on whether you use the x86 or x64 build, respectively) to the 86Box directory. Discord integration will not be available if the Discord desktop app is not running.
 
 * **Take screenshot:** take a screenshot of the emulated display. Screenshots are saved as .png images in the ``screenshots`` subdirectory found in the emulated machine's directory.
 


### PR DESCRIPTION
The Game SDK library is no longer distributed with 86Box itself, therefore a link to the SDK is provided.