### PR TITLE
Add a section for creating and using disk images

### DIFF
--- a/hardware/diskimages.rst
+++ b/hardware/diskimages.rst
@@ -361,7 +361,7 @@ For fixed-size ``vhd`` files the following command may work depending your your 
 Various: Windows
 ^^^^^^^^^^^^^^^^^
 
-On Windows you can use WinImage (paid software) to create and manipulate disk images.
+On Windows you can use WinImage to create and manipulate disk images.
 
 Windows will also allow you to directly mount a ``vhd`` file in order to copy files. The ``Disk Management`` utility allows you to attach a ``vhd`` file by selecting ``Action -> Attach VHD`` from the menu.
 

--- a/hardware/diskimages.rst
+++ b/hardware/diskimages.rst
@@ -271,3 +271,100 @@ Supported formats:
   * - JRipCart
     - .jrc
     -
+
+Creating and using disk images
+------------------------------
+
+Disk images are a convenient way to transfer files in and out of your machine without the need to configure networking. Perhaps your OS doesn't support networking or you don't want to deal with the added complexity of configuring networking on legacy operating systems.
+
+The tooling available varies by host operating system, ranging from command-line tools to full GUI.
+
+Floppy: mtools (Linux, macOS)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `mtools <https://www.gnu.org/software/mtools/>`_ suite is "a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them." With ``mtools`` you can create floppy disk images and copy files to the image. The resulting image can be mounted in 86Box. ``mtools`` can be installed via homebrew on macOS and is available in the standard package repositories on linux.
+
+.. warning:: Never use a tool or utility to write to a disk image that is currently mounted by 86Box. Doing so can lead to unpredictable results, including filesystem corruption.
+
+Creating floppy images
+**********************
+
+The following command will create a 1.4M (1440K, double-sided, 18 sectors per track, 80 cylinders) floppy image named ``floppy.img`` with a label of ``LABEL``:
+
+.. code-block::
+
+  mformat -f 1440 -v LABEL -C -i floppy.img ::
+
+The ``-f`` option specifies the format of the floppy being created. The command can be adjusted for format, label, and image name as needed.
+
+Please see the `mtools documentation <https://www.gnu.org/software/mtools/manual/mtools.html#mformat>`_ for more information on the supported formats.
+
+Copying files to floppy images
+******************************
+
+The following command will copy ``file1`` and ``file2`` to the floppy image ``floppy.img``:
+
+.. code-block::
+
+  mcopy -i floppy.img file1 file2 ::
+
+Wildcards are also supported with ``mcopy``.
+
+.. note:: The ``::`` is required to let ``mtools`` know there are no more files to copy or arguments to process.
+
+CD-ROM: macOS
+^^^^^^^^^^^^^
+
+macOS can natively mount CD-ROM ISOs, but to create them you'll need to open up the terminal.
+
+The following command creates an ISO file named ``cdrom.iso`` with the volume name ``CDROM``.
+
+.. code-block::
+
+  hdiutil makehybrid -iso -joliet -joliet-volume-name "CDROM" -o /path/to/cdrom.iso /path/to/cd/root
+
+In the above example the directory ``/path/to/cd/root`` becomes the root directory of the ISO image.
+
+If you wanted your current working directory to be the ISO root filesystem you could use the following command:
+
+.. code-block::
+
+  hdiutil makehybrid -iso -joliet -joliet-volume-name "CDROM" -o ../cdrom.iso .
+
+.. note:: Make sure the output filename with ``-o`` has a path outside of the filesystem root.
+
+CD-ROM: Linux
+^^^^^^^^^^^^^
+
+Linux provides the ``mkisofs`` tool in order to easily create ISO images. The following command creates the ISO file ``cdrom.iso`` which contains the contents of the directory ``/path/to/cd/root``:
+
+.. code-block::
+
+  mkisofs -o cdrom.iso /path/to/cd/root
+
+.. note::
+  This package is available in the standard distribution repositories, generally under the ``mkisofs`` or ``genisoimage`` package names.
+
+Disk Image: macOS
+^^^^^^^^^^^^^^^^^
+
+macOS can natively mount raw disk images (floppy or hard disk) of types ``FAT16`` and ``FAT32``. Simply double click the file in Finder to mount the image.
+
+For fixed-size ``vhd`` files the following command may work depending your your macOS version:
+
+.. code-block::
+
+  hdiutil attach -imagekey diskimage-class=CRawDiskImage /path/to/your/vhd
+
+.. note:: As with any image file in macOS, the image can only be mounted if macOS can read the underlying filesystem. macOS can read both ``FAT16`` and ``FAT32``.
+
+Various: Windows
+^^^^^^^^^^^^^^^^^
+
+On Windows you can use WinImage (paid software) to create and manipulate disk images.
+
+Windows will also allow you to directly mount a ``vhd`` file in order to copy files. The ``Disk Management`` utility allows you to attach a ``vhd`` file by selecting ``Action -> Attach VHD`` from the menu.
+
+.. warning:: As above, make sure that two different applications never mount the same image file simultaneously. For example, do not mount a ``vhd`` with Windows that is currently mounted by 86Box.
+
+Windows also provides command-line functionality via the ``diskpart`` command. The documentation can located `here <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/diskpart>`_.

--- a/usage/gettingstarted.rst
+++ b/usage/gettingstarted.rst
@@ -41,6 +41,8 @@ To release the mouse, press :kbd:`F8 + F12` simultaneously (on Windows) or :kbd:
 
 If you made it this far, you got the basics of using 86Box, but there's more features and options to explore. For example, you can try out `86Box Manager <https://github.com/86Box/86BoxManager>`_ for easier management of multiple emulated machines. You can see what's under the *View* menu, or look at some of the more obscure options in the *Settings* window.
 
-Keep in mind that because 86Box is constantly in development, various problems will come and go. If you think something's not working the way it should, consider submitting an issue here on GitHub or joining official support channels on Discord or IRC.
+You may eventually encounter the need to get files *into* your machine. Please see :ref:`this section for information on disk image formats<hardware/diskimages:Disk images>` and :ref:`this section on creating and using disk images<hardware/diskimages:Creating and using disk images>`.
+
+Keep in mind that because 86Box is constantly in development, various problems will come and go. If you think something's not working the way it should, consider `submitting an issue on GitHub <https://github.com/86Box/86Box/issues>`_ or joining official support channels on Discord or IRC.
 
 Have fun!


### PR DESCRIPTION
Since there are often questions about copying files into the machine I decided to try and document the methods involving disk images. If anything, it would be handy to be able to point new users to something official to get them started.

As with all documentation, structuring and organizing it is often a challenge. I tried to follow the existing format here when possible. I can change it around it if necessary.

I also added a quick paragraph in the final step of getting started to point to the disk image sections. 

The windows section is kind of sparse because it isn't my main OS. I think it should be a good enough starting point and perhaps others can add to it.