### PR TITLE
buildguide: add a note describing the possible error with libevdev on…

### DIFF
--- a/dev/buildguide.rst
+++ b/dev/buildguide.rst
@@ -160,6 +160,8 @@ FreeBSD
 
     $ pkg install pkgconf freetype-gl sdl2 libspng openal-soft rtmidi qt5 libslirp fluidsynth
 
+.. note:: On FreeBSD, you might need to edit the ``libevdev.h`` file, resides in ``/usr/local/include/libevdev/`` and replace the following ``linux/input.h`` file with ``dev/evdev/input.h``. After that run the ``make`` command once again.
+
 Building
 --------
 


### PR DESCRIPTION
There seem to be a "port" of GNU/Linux's libevdev on FreeBSD. However, it's not exactly a port, and it includes linux/input.h file which on FreeBSD doesn't exist. The equivalent file for linux/input.h is dev/evdev/input.h.

Unless the upstream maintainer of libevdev adds this (may not), we should add a note here, describing the possible error on compilation of 86Box on FreeBSD.