### PR TITLE
prevent build error about missing libz.a

### DIFF
--- a/dev/buildguide.rst
+++ b/dev/buildguide.rst
@@ -142,7 +142,7 @@ Fedora
 .. code-block:: bash
 
     $ sudo dnf groupinstall "C Development Tools and Libraries"
-    $ sudo dnf install cmake extra-cmake-modules pkg-config ninja-build freetype-devel SDL2-devel libatomic libpng-devel libslirp-devel libXi-devel openal-soft-devel rtmidi-devel fluidsynth-devel qt5-linguist qt5-qtconfiguration-devel qt5-qtbase-private-devel qt5-qtbase-static wayland-devel libevdev-devel libxkbcommon-x11-devel
+    $ sudo dnf install cmake extra-cmake-modules pkg-config ninja-build freetype-devel SDL2-devel libatomic libpng-devel libslirp-devel libXi-devel openal-soft-devel rtmidi-devel fluidsynth-devel qt5-linguist qt5-qtconfiguration-devel qt5-qtbase-private-devel qt5-qtbase-static wayland-devel libevdev-devel libxkbcommon-x11-devel zlib-ng-compat-static
 
 
 macOS (Homebrew)


### PR DESCRIPTION
Without this, the build fails with:
```
Make Error at /usr/lib64/cmake/ZLIB/ZLIB.cmake:81 (message):
  The imported target "ZLIB::zlibstatic" references the file

     "/usr/lib64/libz.a"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/usr/lib64/cmake/ZLIB/ZLIB.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /usr/lib64/cmake/ZLIB/zlib-config.cmake:44 (include)
  /usr/share/cmake/Modules/FindPNG.cmake:65 (find_package)
  src/CMakeLists.txt:136 (find_package)
```