### PR TITLE
network: vde_switch does not require root

### DIFF
--- a/hardware/network.rst
+++ b/hardware/network.rst
@@ -96,18 +96,15 @@ Creating the virtual switch
 
 Before connecting 86Box, a virtual switch must be created with the ``vde_switch`` tool.
 
-.. note:: ``vde_switch`` requires root privileges to *create* the switch. Applications will be able to connect to the switch with unprivileged (non-root) permissions.
-
 .. code-block:: shell
 
-  vde_switch --mode 666 --numports 8 --mgmt /tmp/vde.mgmt --mgmtmode 666 -s /tmp/vde.ctl
+  vde_switch --numports 8 --mgmt /tmp/vde.mgmt -s /tmp/vde.ctl
 
 This command:
 
 * Creates the *management* socket at ``/tmp/vde.mgmt``
 * Creates the *control* socket at ``/tmp/vde.ctl``
-* Sets the sockets' permissions to world read/write to allow unprivileged access
-* Sets the number of switch ports to 8
+* Sets the number of switch ports to 8 (default is 32)
 
 Adding ``--daemon`` to the command will run ``vde_switch`` in the background.
 


### PR DESCRIPTION
Just a bit of erronous documentation.  VDE's whole purpose was to run a networking stack as a user without requiring root; vde_switch defaults to setting the UID/GID of the socket to the user that initiated it with mode 0600: plenty good enough for most users (and 86Box usage).

The default socket directory is already /tmp/vde.ctl, too, but might as well keep it in the documentation here so that it's more obvious to change.