### PR TITLE
Document support for AaruFormat and CHD images

### DIFF
--- a/hardware/diskimages.rst
+++ b/hardware/diskimages.rst
@@ -210,13 +210,13 @@ Supported formats:
 
   * - ISO
     - .iso
-    -
+    - Represents only a single data track, no audio tracks supported.
 
   * - Cue sheet
     - .cue + .bin
 
       (+ optional audio)
-    - :ref:`Audio tracks are supported. <hardware/diskimages:CD audio>`
+    -
 
   * - Alcohol 120%
     - .mds + .mdf
@@ -237,9 +237,24 @@ Supported formats:
 CD audio
 ^^^^^^^^
 
-Compact Disc Digital Audio (CDDA) playback through the emulated CD-ROM drives is supported on **AaruFormat**, **Cue sheet**, and **Daemon Tools** images. Audio output is enabled on the first CD-ROM drive and muted on subsequent drives by default; individual drives can be muted or unmuted through the :ref:`status bar <usage/statusbar:|cdrom| |dvdrom| CD-ROM drives>` or :ref:`Media menu <usage/menubar:Media>`.
+Compact Disc Digital Audio (CDDA) playback through the emulated CD-ROM drives is supported with most image formats, with the notable exception of ISO file images. Audio output is enabled on the first CD-ROM drive and muted on subsequent drives by default; individual drives can be muted or unmuted through the :ref:`status bar <usage/statusbar:|cdrom| |dvdrom| CD-ROM drives>` or :ref:`Media menu <usage/menubar:Media>`.
 
 For **Cue sheet** images, audio tracks in raw (.bin), encapsulated (.wav) and compressed (.mp3 .ogg .flac) formats are supported.
+
+Multiple session support
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+CDs containing multiple sessions (sometimes branded “Enhanced CD”) is supported on the **Cue sheet**, **Alcohol 120%**, **Daemon Tools**, and **AaruFormat** image types.  Other image types do not support representing multiple sessions.
+
+For **Cue sheet** images, multiple sessions are implement through an unofficial ``REM SESSION XX`` extension, not supported by the original CDRWIN software nor many other Cue sheet-supporting programs.  An example of a multi-session Cue sheet is as follows::
+
+  FILE "data.bin" BINARY
+  REM SESSION 01
+    TRACK 01 AUDIO
+      INDEX 01 00:00:00
+  REM SESSION 02
+    TRACK 02 MODE2/2352
+      INDEX 01 05:00:00
 
 CHD support
 ^^^^^^^^^^^

--- a/hardware/diskimages.rst
+++ b/hardware/diskimages.rst
@@ -208,15 +208,15 @@ Supported formats:
     - File extension
     - Notes
 
+  * - ISO
+    - .iso
+    -
+
   * - Cue sheet
     - .cue + .bin
 
       (+ optional audio)
     - :ref:`Audio tracks are supported. <hardware/diskimages:CD audio>`
-
-  * - ISO
-    - .iso
-    -
 
   * - Alcohol 120%
     - .mds + .mdf
@@ -226,10 +226,14 @@ Supported formats:
     - .mdx
     - Support will not be available on Windows hosts if the included ``mdsx.dll`` file is missing from the 86Box directory.
 
+  * - `AaruFormat <https://aaru.app/>`_
+    - .aaruf, .aif, .aaruformat
+    - Support for AaruFormat images requires ``libaaruformat.dll`` (Windows), ``libaaruformat.dylib`` (macOS), or ``libaaruformat.so`` (Linux and other Unices)
+
 CD audio
 ^^^^^^^^
 
-Compact Disc Digital Audio (CDDA) playback through the emulated CD-ROM drives is supported on **Cue sheet** and **Daemon Tools** images. Audio output is enabled on the first CD-ROM drive and muted on subsequent drives by default; individual drives can be muted or unmuted through the :ref:`status bar <usage/statusbar:|cdrom| |dvdrom| CD-ROM drives>` or :ref:`Media menu <usage/menubar:Media>`.
+Compact Disc Digital Audio (CDDA) playback through the emulated CD-ROM drives is supported on **AaruFormat**, **Cue sheet**, and **Daemon Tools** images. Audio output is enabled on the first CD-ROM drive and muted on subsequent drives by default; individual drives can be muted or unmuted through the :ref:`status bar <usage/statusbar:|cdrom| |dvdrom| CD-ROM drives>` or :ref:`Media menu <usage/menubar:Media>`.
 
 For **Cue sheet** images, audio tracks in raw (.bin), encapsulated (.wav) and compressed (.mp3 .ogg .flac) formats are supported.
 

--- a/hardware/diskimages.rst
+++ b/hardware/diskimages.rst
@@ -4,7 +4,7 @@ Disk images
 86Box supports a large variety of disk image formats for the emulated storage drives.
 
 .. raw:: html
-  
+
   <style>
     /* There's no getting around Sphinx automatically sizing columns without some CSS.
        It's that kind of recurring issue a lot of people had but nobody ever addressed. */
@@ -226,6 +226,10 @@ Supported formats:
     - .mdx
     - Support will not be available on Windows hosts if the included ``mdsx.dll`` file is missing from the 86Box directory.
 
+  * - `CHD <https://docs.mamedev.org/tools/chdman.html>`_
+    - .chd
+    -
+
   * - `AaruFormat <https://aaru.app/>`_
     - .aaruf, .aif, .aaruformat
     - Support for AaruFormat images requires ``libaaruformat.dll`` (Windows), ``libaaruformat.dylib`` (macOS), or ``libaaruformat.so`` (Linux and other Unices)
@@ -236,6 +240,11 @@ CD audio
 Compact Disc Digital Audio (CDDA) playback through the emulated CD-ROM drives is supported on **AaruFormat**, **Cue sheet**, and **Daemon Tools** images. Audio output is enabled on the first CD-ROM drive and muted on subsequent drives by default; individual drives can be muted or unmuted through the :ref:`status bar <usage/statusbar:|cdrom| |dvdrom| CD-ROM drives>` or :ref:`Media menu <usage/menubar:Media>`.
 
 For **Cue sheet** images, audio tracks in raw (.bin), encapsulated (.wav) and compressed (.mp3 .ogg .flac) formats are supported.
+
+CHD support
+^^^^^^^^^^^
+
+CHD files are most often seen in software sets intended for the `MAME <https://www.mamedev.org/>`_ emulator, but other sources exist, including self-made images created with the ``chdman`` utility.  86Box only supports CHDs that represent CD and DVD media, other CHD types (such as hard disk and LaserDisc) are not supported.
 
 Cassette tape images
 --------------------


### PR DESCRIPTION
I believe Aaru can retain multi-session discs in a single image file, but I do not presently have a disc I can dump and test that with.  It should probably be noted specially that this would be an advantage of the format.