### PR TITLE
machinespecific: remove caveat that PCjr doesn’t support hard disks

### DIFF
--- a/hardware/machinespecific.rst
+++ b/hardware/machinespecific.rst
@@ -18,7 +18,6 @@ This |page| contains important notes related to specific machine models emulated
 .. rubric:: IBM PCjr
 
 * Some applications may shift the display slightly to one side due to unconventional use of the PCjr video hardware. Unchecking the **Apply overscan deltas** option accessible through the internal video's :ref:`Configure button <settings/display:Video>` can help bring the display back into position.
-* Hard disks are not supported, as a PCjr-compatible hard disk controller is not emulated by 86Box.
 
 .. _ibmxt:
 .. rubric:: IBM XT


### PR DESCRIPTION
As pointed out by Harrison (“k11328665”) and jriwanek, the jr-IDE controller was added in version 6.0, and some SCSI controllers are supported on the machine as well.